### PR TITLE
Bump compileSdkVersion 28 to build with Android X

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
A new property has been introduced on Android SDK 28, and unless all plugins are upgraded, we can't compile new Flutter apps with it.

https://github.com/flutter/flutter/issues/46881

When running `flutter build apk --release` with this plugin using a migrated AndroidX Flutter app, we get an error:

```
* What went wrong:
Execution failed for task ':launcher_assist:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed
     C:\Users\bltav\.gradle\caches\transforms-2\files-2.1\9a11db4e12b8021595ff7add8f15436d\core-1.0.0\res\values\values.xml:57:5-88:25: AAPT: error: resource android:attr/fontVariationSettings not found.

     C:\Users\bltav\.gradle\caches\transforms-2\files-2.1\9a11db4e12b8021595ff7add8f15436d\core-1.0.0\res\values\values.xml:57:5-88:25: AAPT: error: resource android:attr/ttcIndex not found.
```