### PR TITLE
Migration to AndroidX and compileSdkVersion update to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx1536M
+


### PR DESCRIPTION
This pull request solves issue I opened here:
https://github.com/hathibelagal-dev/launcher-assist-for-flutter/issues/11

Project's `compileSdkVersion` updated to 28, build gradle updated to `3.5.3`, also migrated to AndroidX.
Build error no longer appears in my case.